### PR TITLE
update README.md about `invalid multibyte char (US-ASCII)` exception in ruby 1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ And then execute:
 
 ```ruby
 # config/initializers/limiter.rb
+
+# -*- encoding : utf-8 -*-
 require File.expand_path("../redis", __FILE__)
 Rails.configuration.app_middleware.insert_before(Rack::MethodOverride,
                                                  Limiter::RateLimiter,


### PR DESCRIPTION
README.md 中的例子 "我不是机器人" 在ruby 1.9 中有字符串编码异常。
